### PR TITLE
Adding props notes, displayToggles and styles

### DIFF
--- a/src-docs/src/views/combo_box/single_selection.js
+++ b/src-docs/src/views/combo_box/single_selection.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import { EuiComboBox } from '../../../../src/components';
+import { DisplayToggles } from '../form_controls/display_toggles';
 
 export default class extends Component {
   constructor(props) {
@@ -56,14 +57,21 @@ export default class extends Component {
   render() {
     const { selectedOptions } = this.state;
     return (
-      <EuiComboBox
-        placeholder="Select a single option"
-        singleSelection={{ asPlainText: true }}
-        options={this.options}
-        selectedOptions={selectedOptions}
-        onChange={this.onChange}
-        isClearable={false}
-      />
+      <DisplayToggles
+        canDisabled={false}
+        canReadOnly={false}
+        canLoading={false}
+        canPrepend
+        canAppend>
+        <EuiComboBox
+          placeholder="Select a single option"
+          singleSelection={{ asPlainText: true }}
+          options={this.options}
+          selectedOptions={selectedOptions}
+          onChange={this.onChange}
+          isClearable={false}
+        />
+      </DisplayToggles>
     );
   }
 }

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -74,7 +74,15 @@ interface _EuiComboBoxProps<T>
   placeholder?: string;
   rowHeight?: number;
   singleSelection: boolean | EuiComboBoxSingleSelectionShape;
+  /**
+   * Creates an input group with element(s) coming before input. It only shows when the `singleSelection` is set to `true`.
+   * `string` | `ReactElement` or an array of these
+   */
   prepend?: EuiFormControlLayoutProps['prepend'];
+  /**
+   * Creates an input group with element(s) coming after input. It only shows when the `singleSelection` is set to `true`.
+   * `string` | `ReactElement` or an array of these
+   */
   append?: EuiFormControlLayoutProps['append'];
 }
 

--- a/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -245,6 +245,7 @@ export class EuiComboBoxInput<T> extends Component<
       'euiComboBox__inputWrap--fullWidth': fullWidth,
       'euiComboBox__inputWrap--noWrap': singleSelection,
       'euiComboBox__inputWrap-isClearable': onClear,
+      'euiComboBox__inputWrap--inGroup': prepend || append,
     });
 
     return (


### PR DESCRIPTION
### Summary

This PR is part of https://github.com/elastic/eui/pull/3003/ and it adds:

- Missing props notes
- A display toggle into the **Single selection** section
- A missing `--inGroup` className 


