### PR TITLE
Update prop-loader & usage

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -23,15 +23,15 @@ module.exports = {
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "pegjs-inline-precompile",
-    // "./scripts/babel/proptypes-from-ts-props",
-    // "./scripts/babel/docgen-from-ts-props",
+    "./scripts/babel/proptypes-from-ts-props",
+    "./scripts/babel/docgen-from-ts-props",
     "add-module-exports",
-    // [
-    //   "react-docgen",
-    //   {
-    //     "resolver": "findAllExportedComponentDefinitions"
-    //   }
-    // ],
+    [
+      "react-docgen",
+      {
+        "resolver": "findAllExportedComponentDefinitions"
+      }
+    ],
     // stage 3
     "@babel/proposal-object-rest-spread",
     // stage 2

--- a/src-docs/src/views/color_picker/color_picker_example.js
+++ b/src-docs/src/views/color_picker/color_picker_example.js
@@ -16,7 +16,7 @@ import {
   EuiColorPalettePickerPaletteTextProps,
   EuiColorPalettePickerPaletteFixedProps,
   EuiColorPalettePickerPaletteGradientProps,
-} from '../../../../src/components/color_picker/color_palette_picker/color_palette_picker';
+} from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/color_picker/color_palette_picker/color_palette_picker';
 
 import ColorPicker from './color_picker';
 const colorPickerSource = require('!!raw-loader!./color_picker');

--- a/src-docs/src/views/datagrid/datagrid_controlcolumns_example.js
+++ b/src-docs/src/views/datagrid/datagrid_controlcolumns_example.js
@@ -9,7 +9,7 @@ import DataGridControlColumns from './control_columns';
 const dataGridControlColumnsSource = require('!!raw-loader!./control_columns');
 const dataGridControlColumnsHtml = renderToHtml(DataGridControlColumns);
 
-import { EuiDataGridControlColumn } from '../../../../src/components/datagrid/data_grid_types';
+import { EuiDataGridControlColumn } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_types';
 
 const gridSnippet = `<EuiDataGrid
   {...usualProps}

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -29,10 +29,10 @@ import {
   EuiDataGridPopoverContentProps,
   EuiDataGridControlColumn,
   EuiDataGridToolBarVisibilityColumnSelectorOptions,
-} from '../../../../src/components/datagrid/data_grid_types';
+} from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_types';
 
-import { EuiDataGridCellValueElementProps } from '../../../../src/components/datagrid/data_grid_cell';
-import { EuiDataGridSchemaDetector } from '../../../../src/components/datagrid/data_grid_schema';
+import { EuiDataGridCellValueElementProps } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_cell';
+import { EuiDataGridSchemaDetector } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_schema';
 
 const gridSnippet = `
   <EuiDataGrid

--- a/src-docs/src/views/datagrid/datagrid_memory_example.js
+++ b/src-docs/src/views/datagrid/datagrid_memory_example.js
@@ -37,10 +37,10 @@ import {
   EuiDataGridStyle,
   EuiDataGridToolBarVisibilityOptions,
   EuiDataGridColumnVisibility,
-} from '../../../../src/components/datagrid/data_grid_types';
+} from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_types';
 
-import { EuiDataGridCellValueElementProps } from '../../../../src/components/datagrid/data_grid_cell';
-import { EuiDataGridSchemaDetector } from '../../../../src/components/datagrid/data_grid_schema';
+import { EuiDataGridCellValueElementProps } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_cell';
+import { EuiDataGridSchemaDetector } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_schema';
 
 export const DataGridMemoryExample = {
   title: 'Data grid in-memory settings',
@@ -128,7 +128,6 @@ export const DataGridMemoryExample = {
         </p>
       ),
       props: {
-        EuiDataGrid,
         EuiDataGrid,
         EuiDataGridInMemory,
         EuiDataGridColumn,

--- a/src-docs/src/views/datagrid/datagrid_schema_example.js
+++ b/src-docs/src/views/datagrid/datagrid_schema_example.js
@@ -17,10 +17,10 @@ import {
   EuiDataGridStyle,
   EuiDataGridToolBarVisibilityOptions,
   EuiDataGridColumnVisibility,
-} from '../../../../src/components/datagrid/data_grid_types';
+} from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_types';
 
-import { EuiDataGridCellValueElementProps } from '../../../../src/components/datagrid/data_grid_cell';
-import { EuiDataGridSchemaDetector } from '../../../../src/components/datagrid/data_grid_schema';
+import { EuiDataGridCellValueElementProps } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_cell';
+import { EuiDataGridSchemaDetector } from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_schema';
 
 export const DataGridSchemaExample = {
   title: 'Data grid schemas and popovers',

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -25,7 +25,7 @@ import {
   EuiDataGridColumn,
   EuiDataGridStyle,
   EuiDataGridToolBarVisibilityOptions,
-} from '../../../../src/components/datagrid/data_grid_types';
+} from '!!../../../../scripts/loaders/prop-loader!../../../../src/components/datagrid/data_grid_types';
 
 const gridSnippet = `<EuiDataGrid
   {...usualProps}

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -49,16 +49,6 @@ const webpackConfig = {
         exclude: [/node_modules/, /packages(\/|\\)react-datepicker/],
       },
       {
-        test: /\.(tsx?)$/,
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        use: [path.resolve('scripts/loaders/prop-loader.js')],
-        exclude: [
-          /node_modules/,
-          /packages(\/|\\)react-datepicker/,
-          /src-docs/,
-        ],
-      },
-      {
         test: /\.scss$/,
         loaders: useCache([ // eslint-disable-line react-hooks/rules-of-hooks, prettier/prettier
           'style-loader/useable',


### PR DESCRIPTION
* Modified prop-loader to return only the docgen-replaced types & interfaces
* prop-loader only modifies exported types/interfaces
* Re-enabled existing babel configuration
* Removed prop-loader from webpack config
* Added prop-loader to the import path when importing display props for data grid & color palette picker