### PR TITLE
Include HTMLElement in Props tab if not superseded by another element

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -367,26 +367,30 @@ export class GuideSection extends Component {
     });
 
     const extendedTypes = extendedInterfaces
-      ? extendedInterfaces
-          .filter(type => !!extendedTypesInfo[type])
-          .map(type => (
-            <EuiLink
-              key={`extendedTypeValue-${extendedTypesInfo[type].name}`}
-              className="guideSection__extend-element"
-              href={extendedTypesInfo[type].url}>
-              {extendedTypesInfo[type].name}
-            </EuiLink>
-          ))
+      ? extendedInterfaces.filter(type => !!extendedTypesInfo[type])
       : [];
+    // if there is an HTMLAttributes type present among others, remove HTMLAttributes
+    if (extendedTypes.includes('HTMLAttributes') && extendedTypes.length > 1) {
+      const htmlAttributesIndex = extendedTypes.indexOf('HTMLAttributes');
+      extendedTypes.splice(htmlAttributesIndex, 1);
+    }
+    const extendedTypesElements = extendedTypes.map(type => (
+      <EuiLink
+        key={`extendedTypeValue-${extendedTypesInfo[type].name}`}
+        className="guideSection__extend-element"
+        href={extendedTypesInfo[type].url}>
+        {extendedTypesInfo[type].name}
+      </EuiLink>
+    ));
 
     const title = (
       <p id={componentName}>
         <span>{componentName}</span>
-        {extendedTypes.length > 0 && (
+        {extendedTypesElements.length > 0 && (
           <span
             key={`extendedTypes-${componentName}`}
             className="guideSection__extend">
-            [ extends {extendedTypes}]
+            [ extends {extendedTypesElements}]
           </span>
         )}
       </p>

--- a/src-docs/src/components/guide_section/guide_section_extends.js
+++ b/src-docs/src/components/guide_section/guide_section_extends.js
@@ -1,4 +1,9 @@
 export const extendedTypesInfo = {
+  // HTMLAttributes is removed from display if any of the following elements also exist
+  HTMLAttributes: {
+    name: 'HTMLElement',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement',
+  },
   SelectHTMLAttributes: {
     name: 'HTMLSelectElement',
     url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement',


### PR DESCRIPTION
Added the HTMLAttributes->HTMLElement catch-all, and filter it out when another element is present.